### PR TITLE
Explicitly add aiohttp as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "azure-ai-evaluation>=1.5.0",
     "azure-ai-projects>=1.0.0b9",
     "azure-identity",
-    "aiohttp"
+    "aiohttp>=3.8.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "azure-ai-evaluation>=1.5.0",
     "azure-ai-projects>=1.0.0b9",
     "azure-identity",
+    "aiohttp"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Explicitly add aiohttp as dependency to avoid the module not found error from the evaluation SDK