### PR TITLE
Fix/72 eval name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To use this action, all you need to provide is a data set with test queries and 
 | data-path                 |    Yes    | Path to the data file that contains the evaluators and input queries for evaluations                                                                                                          |
 | agent-ids                 |    Yes    | ID of the agent(s) to evaluate in format `agent-name:version` (e.g., `my-agent:1` or `my-agent:1,my-agent:2`). Multiple agents are comma-separated and compared with statistical test results |
 | baseline-agent-id         |    No     | ID of the baseline agent to compare against when evaluating multiple agents. If not provided, the first agent is used                                                                         |
+| eval-name                 |    No     | Name to assign to the eval object created in Foundry. Useful for distinguishing evals from multiple pipelines, repos, or environments. Defaults to `"Agent Evaluation"`                      |
 
 ### Data file
 

--- a/action.py
+++ b/action.py
@@ -47,6 +47,7 @@ DEPLOYMENT_NAME = os.getenv("DEPLOYMENT_NAME")
 DATA_PATH = os.getenv("DATA_PATH")
 AGENT_IDS = [x.strip() for x in os.getenv("AGENT_IDS", "").split(",") if x.strip()]
 BASELINE_AGENT_ID = os.getenv("BASELINE_AGENT_ID")
+EVAL_NAME = os.getenv("EVAL_NAME") or "Agent Evaluation"
 
 
 def get_agents(project_client: AIProjectClient, agent_ids: list[str]) -> dict:
@@ -605,6 +606,7 @@ def create_evaluation_and_dataset(
     input_data_path: Path,
     input_data: dict,
     evaluator_metadata: dict,
+    eval_name: str = "Agent Evaluation",
 ) -> tuple:
     """Create evaluation object and upload dataset.
 
@@ -614,6 +616,7 @@ def create_evaluation_and_dataset(
         input_data_path: Path to input data file
         input_data: Input data dictionary
         evaluator_metadata: Evaluator metadata with categories
+        eval_name: Name to assign to the evaluation object in Foundry
 
     Returns:
         Tuple of (eval_object, dataset, display_name_to_evaluator_name)
@@ -640,7 +643,7 @@ def create_evaluation_and_dataset(
     )
 
     eval_object = openai_client.evals.create(
-        name="Agent Evaluation",
+        name=eval_name,
         data_source_config=data_source_config,
         testing_criteria=testing_criteria,  # type: ignore
     )
@@ -715,6 +718,7 @@ def main(
     input_data: dict,
     agent_ids: list[str],
     baseline_agent_id: str | None = None,
+    eval_name: str = "Agent Evaluation",
 ) -> str:
     """Main evaluation workflow.
 
@@ -744,6 +748,7 @@ def main(
                 input_data_path,
                 input_data,
                 evaluator_metadata,
+                eval_name,
             )
         )
 
@@ -857,6 +862,7 @@ def _validate_environment_variables() -> dict:
         "data_path": DATA_PATH,
         "agent_ids": AGENT_IDS,
         "baseline_agent_id": BASELINE_AGENT_ID,
+        "eval_name": EVAL_NAME,
     }
 
 
@@ -880,6 +886,7 @@ if __name__ == "__main__":
         input_data=data,
         agent_ids=env_config["agent_ids"],
         baseline_agent_id=env_config["baseline_agent_id"],
+        eval_name=env_config["eval_name"],
     )
 
     if STEP_SUMMARY:

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
       Agent ID of the baseline agent to compare against when evaluating multiple agents. If not provided, the first
       agent is used.
     required: false
+  eval-name:
+    description: Name to assign to the eval object created in Foundry. Useful for distinguishing evals from multiple pipelines, repos, or environments.
+    required: false
+    default: "Agent Evaluation"
   api-version:
     description: The API version to use when connecting to model deployment.
     required: false
@@ -56,3 +60,4 @@ runs:
         DATA_PATH: ${{ inputs.data-path }}
         AGENT_IDS: ${{ inputs.agent-ids }}
         BASELINE_AGENT_ID: ${{ inputs.baseline-agent-id }}
+        EVAL_NAME: ${{ inputs.eval-name }}

--- a/tasks/AIAgentEvaluation/V3/index.ts
+++ b/tasks/AIAgentEvaluation/V3/index.ts
@@ -141,6 +141,7 @@ async function run() {
       { name: "data-path", required: true },
       { name: "agent-ids", required: true },
       { name: "baseline-agent-id", required: false },
+      { name: "eval-name", required: false },
     ];
     inputs.forEach((input) => {
       const value = tl.getInput(input.name, input.required);

--- a/tasks/AIAgentEvaluation/V3/task.json
+++ b/tasks/AIAgentEvaluation/V3/task.json
@@ -54,6 +54,14 @@
       "helpMarkDown": "Agent ID of the baseline agent to compare against. By default, the first agent is used."
     },
     {
+      "name": "eval-name",
+      "type": "string",
+      "label": "Eval Name",
+      "defaultValue": "Agent Evaluation",
+      "required": false,
+      "helpMarkDown": "Name to assign to the eval object created in Foundry. Useful for distinguishing evals from multiple pipelines, repos, or environments."
+    },
+    {
       "name": "api-version",
       "type": "string",
       "label": "API Version",


### PR DESCRIPTION
This pull request introduces a new optional configuration, `eval-name`, allowing users to specify a custom name for the evaluation object created in Foundry. This enhancement improves traceability and organization when running multiple evaluations across different pipelines, repositories, or environments. The change is implemented across documentation, configuration files, and the main workflow logic.

**Main features and changes:**

**New configuration option for evaluation naming:**

* Added the `eval-name` input to `action.yml` and `tasks/AIAgentEvaluation/V3/task.json`, allowing users to set a custom name for the evaluation object. Defaults to `"Agent Evaluation"` if not specified. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R30-R33) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R63) [[3]](diffhunk://#diff-5f3e265e50ac276d5dae51cb8ccfac819dd2602ea50fe6971c1992eb9aedf99dR56-R63) [[4]](diffhunk://#diff-e78c6f11ce6e2b62450bd8ff625309559f7621fbc6acbaaf2acf5b391def031fR144)
* Updated the documentation in `README.md` to describe the new `eval-name` option and its intended use for distinguishing between different evaluation runs.

**Workflow and environment propagation:**

* Passed the `eval-name` input as an environment variable (`EVAL_NAME`) throughout the workflow, ensuring it is available to the evaluation logic. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R63) [[2]](diffhunk://#diff-fb9ef24deb644d768a5b3156bba38a82ab98cb01fb6cfeb8515f9460e46f2d08R50) [[3]](diffhunk://#diff-fb9ef24deb644d768a5b3156bba38a82ab98cb01fb6cfeb8515f9460e46f2d08R865)
* Modified the main Python workflow in `action.py` to accept, validate, and propagate the `eval_name` parameter, using it when creating the evaluation object in Foundry. [[1]](diffhunk://#diff-fb9ef24deb644d768a5b3156bba38a82ab98cb01fb6cfeb8515f9460e46f2d08R609) [[2]](diffhunk://#diff-fb9ef24deb644d768a5b3156bba38a82ab98cb01fb6cfeb8515f9460e46f2d08R619) [[3]](diffhunk://#diff-fb9ef24deb644d768a5b3156bba38a82ab98cb01fb6cfeb8515f9460e46f2d08L643-R646) [[4]](diffhunk://#diff-fb9ef24deb644d768a5b3156bba38a82ab98cb01fb6cfeb8515f9460e46f2d08R721) [[5]](diffhunk://#diff-fb9ef24deb644d768a5b3156bba38a82ab98cb01fb6cfeb8515f9460e46f2d08R751) [[6]](diffhunk://#diff-fb9ef24deb644d768a5b3156bba38a82ab98cb01fb6cfeb8515f9460e46f2d08R889)

These changes make it easier to manage and identify evaluation runs, especially in environments with multiple concurrent or historical evaluations.